### PR TITLE
Fix Author command compilation with updated console API

### DIFF
--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -22,8 +22,8 @@ void CGameContext::ConAuthor(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	// Reject from in-game clients; allow only via rcon/server console
-	int CallerCid = pResult->GetClientId();
+        // Reject from in-game clients; allow only via rcon/server console
+        int CallerCid = pResult->m_ClientId;
 	if(CallerCid >= 0)
 	{
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "author", "This command is available only via rcon.");


### PR DESCRIPTION
## Summary
- use `m_ClientId` instead of removed `GetClientId` in `ConAuthor`

## Testing
- `cmake .. -DCLIENT=OFF -DSERVER=ON -DMYSQL=ON -DCMAKE_BUILD_TYPE=Release`
- `make -j4 DDNet-Server`

------
https://chatgpt.com/codex/tasks/task_e_68a485136718832ca969d020fceac18d