### PR TITLE
Fix author command to work via rcon and restrict to admins

### DIFF
--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -22,11 +22,11 @@ void CGameContext::ConAuthor(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-        // Reject from in-game clients; allow only via rcon/server console
-        int CallerCid = pResult->m_ClientId;
-	if(CallerCid >= 0)
+	// Allow execution from rcon/econ, but restrict in-game usage to admins
+	int CallerCid = pResult->m_ClientId;
+	if(CallerCid >= 0 && pSelf->Server()->GetAuthedState(CallerCid) != AUTHED_ADMIN)
 	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "author", "This command is available only via rcon.");
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "author", "Only admins can use this command.");
 		return;
 	}
 
@@ -48,9 +48,16 @@ void CGameContext::ConAuthor(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	// Execute with full admin privileges
+	int OldLevel = IConsole::ACCESS_LEVEL_ADMIN;
+	if(CallerCid >= 0)
+	{
+		int AuthLevel = pSelf->Server()->GetAuthedState(CallerCid);
+		OldLevel = AuthLevel == AUTHED_ADMIN ? IConsole::ACCESS_LEVEL_ADMIN :
+		AuthLevel == AUTHED_MOD ? IConsole::ACCESS_LEVEL_MOD : IConsole::ACCESS_LEVEL_HELPER;
+	}
 	pSelf->Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_ADMIN);
 	pSelf->Console()->ExecuteLine(aCmd, TargetCid, false);
-	pSelf->Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_ADMIN);
+	pSelf->Console()->SetAccessLevel(OldLevel);
 
 	char aBuf[128];
 	str_format(aBuf, sizeof(aBuf), "Executed as cid=%d: %s", TargetCid, aCmd);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3787,7 +3787,7 @@ void CGameContext::OnConsoleInit()
 
 	RegisterDDRaceCommands();
 	RegisterChatCommands();
-	Console()->Register("author", "i[client_id] r[command...]", CFGFLAG_SERVER, ConAuthor, this, "Execute a command as another player (RCON only)");
+        Console()->Register("author", "i[client_id] r[command...]", CFGFLAG_SERVER, ConAuthor, this, "Execute a command as another player (admin only)");
 }
 
 void CGameContext::RegisterDDRaceCommands()


### PR DESCRIPTION
## Summary
- allow `author` command to be run from rcon/econ
- keep execution admin-only and restore caller's access level
- update `author` command help text

## Testing
- `cmake -S . -B build -GNinja` *(fails: glslangValidator binary was not found)*
- `cargo test` *(fails: environment variable DDNET_TEST_LIBRARIES required but not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49d581f08832caea8f8eb2e39767d