### PR TITLE
Add fake player admin commands and Gores test mode

### DIFF
--- a/.github/workflows/build-ddnet.yml
+++ b/.github/workflows/build-ddnet.yml
@@ -1,0 +1,5 @@
+name: Build DDNet-Server
+on:
+  workflow_dispatch:      # даст кнопку Run
+  push:                   # запустится от любого коммита
+    branches: [ main ]    # или твоя ветка

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,312 +1,40 @@
-name: Build
+name: Build DDNet-Server
 
 on:
-  push:
-    branches-ignore:
-      - gh-readonly-queue/**
-  pull_request:
-  merge_group:
+  workflow_dispatch:  # запуск вручную с кнопки "Run workflow"
 
 jobs:
-  build-cmake:
-    runs-on: ${{ matrix.os }}
-    env:
-      CARGO_HTTP_MULTIPLEXING: false
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [ubuntu-latest, macOS-latest, windows-latest, ubuntu-22.04, windows-latest-mingw]
-        include:
-        - name: ubuntu-latest
-          os: ubuntu-latest
-          cmake-args: -G Ninja
-          cmake-init-env: CXXFLAGS=-Werror
-          package-file: "*-linux_x86_64.tar.xz"
-          fancy: true
-        - name: ubuntu-22.04
-          os: ubuntu-22.04
-          cmake-path: /usr/bin/
-          cmake-args: -G Ninja -DTEST_MYSQL=ON
-          cmake-init-env: CXXFLAGS=-Werror
-          gtest-env: GTEST_FILTER=-*SQLite*
-          package-file: "*-linux_x86_64.tar.xz"
-          fancy: false
-        - name: macOS-latest
-          os: macOS-latest
-          cmake-args: -G Ninja
-          cmake-init-env: CXXFLAGS=-Werror
-          package-file: "*-macos.dmg"
-          fancy: false
-        - name: windows-latest
-          os: windows-latest
-          cmake-args: -A x64 -DEXCEPTION_HANDLING=ON
-          cmake-init-env: CXXFLAGS=/WX LDFLAGS=/WX
-          package-file: "*-win64.zip"
-          fancy: false
-        - name: windows-latest-mingw
-          os: windows-latest
-          cmake-args: -G Ninja -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DEXCEPTION_HANDLING=ON -DCMAKE_RC_COMPILER=windres -DCMAKE_AR=ar
-          cmake-init-env: CXXFLAGS=-Werror LDFLAGS=-Werror
-          package-file: "*-win64.zip"
-          fancy: false
-
+  build:
+    runs-on: ubuntu-latest
+    container: debian:bookworm    # собираем прямо в Debian
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
+      - uses: actions/checkout@v4
 
-    - name: Prepare Linux
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        sudo apt-get update -y
-        # mount: /var/lib/grub/esp: special device /dev/disk/by-id/scsi-... does not exist.
-        # sudo apt-get upgrade -y
-        sudo apt-get install pkg-config ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libvulkan-dev glslang-tools spirv-tools libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev libpng-dev valgrind gcovr libglew-dev -y
+      - name: Install build tools
+        run: |
+          apt-get update
+          apt-get install -y git cmake ninja-build build-essential \
+                             libssl-dev zlib1g-dev libmariadb-dev patchelf
 
-    - name: Prepare Linux (non-fancy)
-      if: contains(matrix.os, 'ubuntu') && !matrix.fancy
-      run: |
-        curl -LO https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz
-        sudo tar --strip-components 1 -C /usr -xf cmake-3.13.4-Linux-x86_64.tar.gz
-        # Our minimum supported Rust version (MSRV)
-        rustup default 1.63.0
-        sudo rm -rf /var/lib/mysql/ /var/run/mysqld
-        sudo mkdir /var/lib/mysql/ /var/run/mysqld/
-        sudo chown mysql:mysql /var/lib/mysql/ /var/run/mysqld/
-        sudo mysqld --initialize-insecure --user=mysql --basedir=/usr --datadir=/var/lib/mysql/
-        sudo /usr/bin/mysqld_safe --basedir=/usr --datadir='/var/lib/mysql/' &
-        sleep 10
-        sudo mysql <<EOF
-        CREATE DATABASE ddnet;
-        CREATE USER 'ddnet'@'localhost' IDENTIFIED BY 'thebestpassword';
-        GRANT ALL PRIVILEGES ON ddnet.* TO 'ddnet'@'localhost';
-        FLUSH PRIVILEGES;
-        EOF
+      - name: Configure CMake
+        run: |
+          cmake -S . -B build -G Ninja \
+                -DCLIENT=OFF -DSERVER=ON -DMYSQL=OFF -DCMAKE_BUILD_TYPE=Release
 
-    - name: Prepare Linux (fancy)
-      if: contains(matrix.os, 'ubuntu') && matrix.fancy
-      run: |
-        sudo apt-get install cmake libmariadb-dev libwebsockets-dev mariadb-server -y
-        sudo systemctl stop mysql
-        sudo rm -rf /var/lib/mysql/
-        sudo mysql_install_db --user=mysql --datadir=/var/lib/mysql/
-        cd /usr; sudo mysqld_safe --datadir='/var/lib/mysql/' --no-watch
-        sleep 10
-        sudo mysql <<EOF
-        CREATE DATABASE ddnet;
-        CREATE USER 'ddnet'@'localhost' IDENTIFIED BY 'thebestpassword';
-        GRANT ALL PRIVILEGES ON ddnet.* TO 'ddnet'@'localhost';
-        FLUSH PRIVILEGES;
-        EOF
+      - name: Build
+        run: cmake --build build -j"$(nproc)" --target DDNet-Server
 
-    - name: Prepare macOS
-      if: contains(matrix.os, 'macOS')
-      run: |
-        brew update || true
-        brew install pkg-config sdl2 ffmpeg ninja molten-vk vulkan-headers glslang spirv-tools rust || true
-        brew upgrade freetype
-        pip3 install --break-system-packages dmgbuild
-        echo /Library/Frameworks/Python.framework/Versions/3.12/bin >> $GITHUB_PATH
-        sudo rm -rf /Library/Developer/CommandLineTools
+      - name: Bundle with libs
+        run: |
+          mkdir -p build/package/libs
+          cp build/DDNet-Server build/package/
+          ldd build/DDNet-Server | awk '/=> \//{print $3}' | \
+            grep -vE 'ld-linux|linux-vdso' | xargs -I{} cp -v {} build/package/libs/
+          patchelf --set-rpath '$ORIGIN/libs' build/package/DDNet-Server
+          tar -C build/package -czf DDNet-Server-bundle.tar.gz .
 
-    - name: Prepare Windows MinGW
-      if: contains(matrix.os, 'windows') && contains(matrix.name, 'mingw')
-      run: |
-        rustup toolchain install stable-x86_64-pc-windows-gnu
-        rustup target add x86_64-pc-windows-gnu
-        rustup default stable-x86_64-pc-windows-gnu
-        rustup set default-host x86_64-pc-windows-gnu
-
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-          workspaces: |
-              src/mastersrv
-              src/masterping
-              ./
-
-    - name: Build mastersrv
-      if: ${{ !contains(matrix.os, 'ubuntu-22.04') }}
-      run: |
-        cd src/mastersrv
-        cargo build
-
-    - name: Build masterping
-      if: ${{ !contains(matrix.os, 'ubuntu-22.04') }}
-      run: |
-        cd src/masterping
-        cargo build
-
-    - name: Build in debug mode
-      run: |
-        mkdir debug
-        cd debug
-        ${{ matrix.cmake-path }}cmake --version
-        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Debug -Werror=dev -DDOWNLOAD_GTEST=ON -DDEV=ON -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=. ..
-        ${{ matrix.cmake-path }}cmake --build . --config Debug --target everything
-
-    - name: Test debug
-      run: |
-        cd debug
-        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.gtest-env }} ${{ matrix.cmake-path }}cmake --build . --config Debug --target run_tests
-
-    - name: Run debug server
-      run: |
-        cd debug
-        ./DDNet-Server shutdown
-
-    - name: Build in release mode
-      run: |
-        mkdir release
-        cd release
-        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Release -Werror=dev -DDOWNLOAD_GTEST=ON -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=. ..
-        ${{ matrix.cmake-path }}cmake --build . --config Release --target everything
-
-    - name: Test release
-      run: |
-        cd release
-        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.gtest-env }} ${{ matrix.cmake-path }}cmake --build . --config Release --target run_tests
-
-    - name: Run release server
-      run: |
-        cd release
-        ./DDNet-Server shutdown
-
-    - name: Build headless client
-      if: contains(matrix.os, 'ubuntu-latest')
-      run: |
-        mkdir headless
-        cd headless
-        ${{ matrix.cmake-path }}cmake -E env CXXFLAGS="--coverage -Werror" ${{ matrix.cmake-path }}cmake -E env LDFLAGS="--coverage -Werror" ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DHEADLESS_CLIENT=ON -DCMAKE_BUILD_TYPE=Debug -Werror=dev -DDOWNLOAD_GTEST=ON -DDEV=ON -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=. ..
-        ${{ matrix.cmake-path }}cmake -E env RUSTFLAGS="-Clink-arg=--coverage" ${{ matrix.cmake-path }}cmake --build . --config Debug
-
-    - name: Test headless client (unit tests)
-      if: contains(matrix.os, 'ubuntu-latest')
-      run: |
-        cd headless
-        ${{ matrix.cmake-path }}cmake -E env RUSTFLAGS="-Clink-arg=--coverage" RUSTDOCFLAGS="-Clink-arg=--coverage" ${{ matrix.cmake-path }}cmake --build . --config Debug --target run_tests
-
-    - name: Upload Codecov report (unit tests)
-      if: contains(matrix.os, 'ubuntu-latest')
-      uses: codecov/codecov-action@v4
-      with:
-        flags: unittests
-
-    - name: Build in release mode with debug info and all features on
-      if: matrix.fancy
-      run: |
-        mkdir fancy
-        cd fancy
-        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDOWNLOAD_GTEST=ON -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=. -DANTIBOT=ON -DWEBSOCKETS=ON ..
-        ${{ matrix.cmake-path }}cmake --build . --config RelWithDebInfo --target everything
-
-    - name: Test fancy
-      if: matrix.fancy
-      run: |
-        cd fancy
-        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.gtest-env }} ${{ matrix.cmake-path }}cmake --build . --config RelWithDebInfo --target run_tests
-
-    - name: Run fancy server
-      if: matrix.fancy
-      run: |
-        cd fancy
-        ./DDNet-Server shutdown
-
-    - name: Run integration tests with Valgrind's Memcheck
-      if: contains(matrix.os, 'ubuntu-latest')
-      run: |
-        # Remove old coverage data:
-        find headless -name '*.gcno' -o -name '*.gcda' -delete
-        cp src/mastersrv/target/debug/mastersrv headless
-        python scripts/integration_test.py --test-mastersrv --valgrind-memcheck headless
-
-    - name: Upload Codecov report (integration tests)
-      if: contains(matrix.os, 'ubuntu-latest')
-      uses: codecov/codecov-action@v4
-      with:
-        flags: integrationtests
-
-    - name: Package
-      run: |
-        cd release
-        ${{ matrix.cmake-path }}cmake --build . --config Release --target package_default
-        mkdir artifacts
-        mv ${{ matrix.package-file }} artifacts
-
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: ddnet-${{ matrix.name }}
-        path: release/artifacts
-
-  build-android:
-    runs-on: ubuntu-24.04
-    env:
-      CARGO_HTTP_MULTIPLEXING: false
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: Validate Gradle Wrapper
-      uses: gradle/actions/wrapper-validation@v4
-
-    - name: Prepare Linux
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install cmake ninja-build openjdk-21-jdk p7zip-full curl glslang-tools openssl
-        cargo install cargo-ndk
-        rustup target add armv7-linux-androideabi
-        rustup target add i686-linux-android
-        rustup target add aarch64-linux-android
-        rustup target add x86_64-linux-android
-        mkdir ~/Android
-        cd ~/Android
-        mkdir Sdk
-        cd Sdk
-        mkdir ndk
-        cd ndk
-        wget --quiet https://dl.google.com/android/repository/android-ndk-r26d-linux.zip
-        unzip android-ndk-r26d-linux.zip
-        rm android-ndk-r26d-linux.zip
-        cd ~/Android/Sdk
-        mkdir build-tools
-        cd build-tools
-        wget --quiet https://dl.google.com/android/repository/build-tools_r30.0.3-linux.zip
-        unzip build-tools_r30.0.3-linux.zip
-        rm build-tools_r30.0.3-linux.zip
-        mv android-11 30.0.3
-        cd ~/Android/Sdk
-        mkdir cmdline-tools
-        cd cmdline-tools
-        wget --quiet https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
-        unzip commandlinetools-linux-11076708_latest.zip
-        rm commandlinetools-linux-11076708_latest.zip
-        mv cmdline-tools latest
-        yes | latest/bin/sdkmanager --licenses
-
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-          workspaces: |
-              src/mastersrv
-              src/masterping
-              ./
-
-    - name: Build Android app
-      env:
-        TW_KEY_NAME: /home/runner/DDNet.jks
-        TW_KEY_ALIAS: DDNet-Key
-      run: |
-        export TW_KEY_PW="$(openssl rand -base64 32)"
-        keytool -genkey -v -keystore "$TW_KEY_NAME" -keyalg RSA -keysize 2048 -validity 10000 -alias "$TW_KEY_ALIAS" -storepass "$TW_KEY_PW" -dname "CN=DDNet CI, OU=DDNet, O=DDNet"
-        mkdir build-android
-        scripts/android/cmake_android.sh all DDNet org.ddnet.client Release build-android
-        mkdir artifacts
-        mv build-android/DDNet.apk artifacts
-
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: ddnet-android
-        path: artifacts
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddnet-bundle
+          path: DDNet-Server-bundle.tar.gz

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -281,8 +281,9 @@ public:
 	virtual bool SetTimedOut(int ClientId, int OrigId) = 0;
 	virtual void SetTimeoutProtected(int ClientId) = 0;
 
-	virtual void SetErrorShutdown(const char *pReason) = 0;
-	virtual void ExpireServerInfo() = 0;
+        virtual void SetErrorShutdown(const char *pReason) = 0;
+        virtual void ExpireServerInfo() = 0;
+        virtual void SetFakePlayerCount(int Count) = 0;
 
 	virtual void FillAntibot(CAntibotRoundData *pData) = 0;
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -19,6 +19,7 @@
 #include <engine/shared/console.h>
 #include <engine/shared/demo.h>
 #include <game/server/gamecontext.h>
+#include <game/server/player.h>
 #include <engine/shared/econ.h>
 #include <engine/shared/fifo.h>
 #include <engine/shared/filecollection.h>
@@ -101,7 +102,6 @@ void CServer::UpdateFakePlayers(bool ForceDisconnect)
                         {
                                 int Team = pGameServer->FakeTeam();
                                 pPlayer->SetTeam(Team, false);
-                                pPlayer->m_Spawning = false;
                         }
                 }
                 else if(!Add && Client.m_FakePlayer)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -18,6 +18,7 @@
 #include <engine/shared/config.h>
 #include <engine/shared/console.h>
 #include <engine/shared/demo.h>
+#include <game/server/gamecontext.h>
 #include <engine/shared/econ.h>
 #include <engine/shared/fifo.h>
 #include <engine/shared/filecollection.h>
@@ -53,6 +54,79 @@ using namespace std::chrono_literals;
 #if defined(CONF_PLATFORM_ANDROID)
 extern std::vector<std::string> FetchAndroidServerCommandQueue();
 #endif
+
+void CServer::UpdateFakePlayers(bool ForceDisconnect)
+{
+        if(m_PreviousFakePlayerCount == m_FakePlayerCount && !ForceDisconnect)
+                return;
+
+        m_FakePlayerCount = std::clamp(m_FakePlayerCount, 0, MaxClients());
+        CGameContext *pGameServer = (CGameContext *)GameServer();
+        const auto &Names = pGameServer->FakeNames();
+        int NameCount = Names.size();
+
+        for(int Index = 0; Index < maximum(m_PreviousFakePlayerCount, m_FakePlayerCount); ++Index)
+        {
+                bool Add = !ForceDisconnect && Index < m_FakePlayerCount;
+                int ClientId = MaxClients() - Index - 1;
+                CClient &Client = m_aClients[ClientId];
+
+                if(Add && Client.m_State == CClient::STATE_EMPTY)
+                {
+                        NewClientCallback(ClientId, this, false);
+                        Client.m_DebugDummy = true;
+                        Client.m_FakePlayer = true;
+
+                        Client.m_DebugDummyAddr.type = NETTYPE_IPV6;
+                        Client.m_DebugDummyAddr.ip[0] = 0xfd;
+                        secure_random_fill(&Client.m_DebugDummyAddr.ip[1], 5);
+                        Client.m_DebugDummyAddr.ip[6] = 0xc0;
+                        Client.m_DebugDummyAddr.ip[7] = 0xde;
+                        Client.m_DebugDummyAddr.ip[8] = 0x00;
+                        Client.m_DebugDummyAddr.ip[9] = 0x00;
+                        Client.m_DebugDummyAddr.ip[10] = 0x00;
+                        Client.m_DebugDummyAddr.ip[11] = 0x00;
+                        uint_to_bytes_be(&Client.m_DebugDummyAddr.ip[12], ClientId);
+                        Client.m_DebugDummyAddr.port = (secure_rand() % (65535 - 1024)) + 1024;
+                        net_addr_str(&Client.m_DebugDummyAddr, Client.m_aDebugDummyAddrString.data(), Client.m_aDebugDummyAddrString.size(), true);
+                        net_addr_str(&Client.m_DebugDummyAddr, Client.m_aDebugDummyAddrStringNoPort.data(), Client.m_aDebugDummyAddrStringNoPort.size(), false);
+
+                        pGameServer->OnClientConnected(ClientId, nullptr);
+                        Client.m_State = CClient::STATE_INGAME;
+                        str_copy(Client.m_aName, Names[Index % NameCount].c_str());
+                        pGameServer->OnClientEnter(ClientId);
+
+                        CPlayer *pPlayer = pGameServer->m_apPlayers[ClientId];
+                        if(pPlayer)
+                        {
+                                int Team = pGameServer->FakeTeam();
+                                pPlayer->SetTeam(Team, false);
+                                pPlayer->m_Spawning = false;
+                        }
+                }
+                else if(!Add && Client.m_FakePlayer)
+                {
+                        DelClientCallback(ClientId, "Dropping fake player", this);
+                }
+
+                if(Add && Client.m_FakePlayer)
+                {
+                        CNetObj_PlayerInput Input = {0};
+                        Client.m_aInputs[0].m_GameTick = Tick() + 1;
+                        mem_copy(Client.m_aInputs[0].m_aData, &Input, minimum(sizeof(Input), sizeof(Client.m_aInputs[0].m_aData)));
+                        Client.m_LatestInput = Client.m_aInputs[0];
+                        Client.m_CurrentInput = 0;
+                }
+        }
+
+        m_PreviousFakePlayerCount = ForceDisconnect ? 0 : m_FakePlayerCount;
+}
+
+void CServer::SetFakePlayerCount(int Count)
+{
+        m_FakePlayerCount = std::clamp(Count, 0, MaxClients());
+        UpdateFakePlayers(false);
+}
 
 void CServerBan::InitServerBan(IConsole *pConsole, IStorage *pStorage, CServer *pServer)
 {
@@ -222,10 +296,12 @@ void CServer::CClient::Reset()
 	m_LastAckedSnapshot = -1;
 	m_LastInputTick = -1;
 	m_SnapRate = CClient::SNAPRATE_INIT;
-	m_Score = -1;
-	m_NextMapChunk = 0;
-	m_Flags = 0;
-	m_RedirectDropTime = 0;
+        m_Score = -1;
+        m_NextMapChunk = 0;
+        m_Flags = 0;
+        m_RedirectDropTime = 0;
+        m_DebugDummy = false;
+        m_FakePlayer = false;
 }
 
 CServer::CServer()
@@ -249,14 +325,17 @@ CServer::CServer()
 		m_aCurrentMapSize[i] = 0;
 	}
 
-	m_MapReload = false;
-	m_SameMapReload = false;
-	m_ReloadedWhenEmpty = false;
-	m_aCurrentMap[0] = '\0';
-	m_pCurrentMapName = m_aCurrentMap;
-	m_aMapDownloadUrl[0] = '\0';
+        m_MapReload = false;
+        m_SameMapReload = false;
+        m_ReloadedWhenEmpty = false;
+        m_aCurrentMap[0] = '\0';
+        m_pCurrentMapName = m_aCurrentMap;
+        m_aMapDownloadUrl[0] = '\0';
 
-	m_RconClientId = IServer::RCON_CID_SERV;
+        m_FakePlayerCount = 0;
+        m_PreviousFakePlayerCount = 0;
+
+        m_RconClientId = IServer::RCON_CID_SERV;
 	m_RconAuthLevel = AUTHED_ADMIN;
 
 	m_ServerInfoFirstRequest = 0;
@@ -576,9 +655,10 @@ int CServer::Init()
 		Client.m_Snapshots.Init();
 		Client.m_Traffic = 0;
 		Client.m_TrafficSince = 0;
-		Client.m_ShowIps = false;
-		Client.m_DebugDummy = false;
-		Client.m_AuthKey = -1;
+                Client.m_ShowIps = false;
+                Client.m_DebugDummy = false;
+                Client.m_FakePlayer = false;
+                Client.m_AuthKey = -1;
 		Client.m_Latency = 0;
 		Client.m_Sixup = false;
 		Client.m_RedirectDropTime = 0;
@@ -672,26 +752,34 @@ const NETADDR *CServer::ClientAddr(int ClientId) const
 {
 	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
 	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot is empty");
+        if(m_aClients[ClientId].m_FakePlayer)
+        {
+                return &m_aClients[ClientId].m_DebugDummyAddr;
+        }
 #ifdef CONF_DEBUG
-	if(m_aClients[ClientId].m_DebugDummy)
-	{
-		return &m_aClients[ClientId].m_DebugDummyAddr;
-	}
+        if(m_aClients[ClientId].m_DebugDummy)
+        {
+                return &m_aClients[ClientId].m_DebugDummyAddr;
+        }
 #endif
-	return m_NetServer.ClientAddr(ClientId);
+        return m_NetServer.ClientAddr(ClientId);
 }
 
 const std::array<char, NETADDR_MAXSTRSIZE> &CServer::ClientAddrStringImpl(int ClientId, bool IncludePort) const
 {
 	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
 	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot is empty");
+        if(m_aClients[ClientId].m_FakePlayer)
+        {
+                return IncludePort ? m_aClients[ClientId].m_aDebugDummyAddrString : m_aClients[ClientId].m_aDebugDummyAddrStringNoPort;
+        }
 #ifdef CONF_DEBUG
-	if(m_aClients[ClientId].m_DebugDummy)
-	{
-		return IncludePort ? m_aClients[ClientId].m_aDebugDummyAddrString : m_aClients[ClientId].m_aDebugDummyAddrStringNoPort;
-	}
+        if(m_aClients[ClientId].m_DebugDummy)
+        {
+                return IncludePort ? m_aClients[ClientId].m_aDebugDummyAddrString : m_aClients[ClientId].m_aDebugDummyAddrStringNoPort;
+        }
 #endif
-	return m_NetServer.ClientAddrString(ClientId, IncludePort);
+        return m_NetServer.ClientAddrString(ClientId, IncludePort);
 }
 
 const char *CServer::ClientName(int ClientId) const
@@ -2582,8 +2670,8 @@ void CServer::UpdateRegisterServerInfo()
 		}
 	}
 
-	int MaxPlayers = maximum(m_NetServer.MaxClients() - maximum(g_Config.m_SvSpectatorSlots, g_Config.m_SvReservedSlots), PlayerCount);
-	int MaxClients = maximum(m_NetServer.MaxClients() - g_Config.m_SvReservedSlots, ClientCount);
+        int MaxPlayers = maximum(m_NetServer.MaxClients() - maximum(g_Config.m_SvSpectatorSlots, g_Config.m_SvReservedSlots), PlayerCount);
+        int MaxClients = maximum(m_NetServer.MaxClients() - g_Config.m_SvReservedSlots, ClientCount);
 	char aMapSha256[SHA256_MAXSTRSIZE];
 
 	sha256_str(m_aCurrentMapSha256[MAP_TYPE_SIX], aMapSha256, sizeof(aMapSha256));
@@ -2628,11 +2716,11 @@ void CServer::UpdateRegisterServerInfo()
 	JsonWriter.WriteAttribute("clients");
 	JsonWriter.BeginArray();
 
-	for(int i = 0; i < MAX_CLIENTS; i++)
-	{
-		if(m_aClients[i].IncludedInServerInfo())
-		{
-			JsonWriter.BeginObject();
+        for(int i = 0; i < MAX_CLIENTS; i++)
+        {
+                if(m_aClients[i].IncludedInServerInfo())
+                {
+                        JsonWriter.BeginObject();
 
 			JsonWriter.WriteAttribute("name");
 			JsonWriter.WriteStrValue(ClientName(i));
@@ -2651,12 +2739,12 @@ void CServer::UpdateRegisterServerInfo()
 
 			GameServer()->OnUpdatePlayerServerInfo(&JsonWriter, i);
 
-			JsonWriter.EndObject();
-		}
-	}
+                        JsonWriter.EndObject();
+                }
+        }
 
-	JsonWriter.EndArray();
-	JsonWriter.EndObject();
+        JsonWriter.EndArray();
+        JsonWriter.EndObject();
 
 	m_pRegister->OnNewInfo(JsonWriter.GetOutputString().c_str());
 }
@@ -3122,9 +3210,10 @@ int CServer::Run()
 					}
 
 #ifdef CONF_DEBUG
-					UpdateDebugDummies(true);
+                                        UpdateDebugDummies(true);
 #endif
-					GameServer()->OnShutdown(m_pPersistentData);
+                                        UpdateFakePlayers(true);
+                                        GameServer()->OnShutdown(m_pPersistentData);
 
 					for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
 					{
@@ -3177,11 +3266,12 @@ int CServer::Run()
 				GameServer()->OnPreTickTeehistorian();
 
 #ifdef CONF_DEBUG
-				UpdateDebugDummies(false);
+                                UpdateDebugDummies(false);
 #endif
+                                UpdateFakePlayers(false);
 
-				for(int c = 0; c < MAX_CLIENTS; c++)
-				{
+                                for(int c = 0; c < MAX_CLIENTS; c++)
+                                {
 					if(m_aClients[c].m_State != CClient::STATE_INGAME)
 						continue;
 					bool ClientHadInput = false;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -82,12 +82,15 @@ class CServer : public IServer
 	UNIXSOCKET m_ConnLoggingSocket;
 #endif
 
-	class CDbConnectionPool *m_pConnectionPool;
+        class CDbConnectionPool *m_pConnectionPool;
 
 #ifdef CONF_DEBUG
-	int m_PreviousDebugDummies = 0;
-	void UpdateDebugDummies(bool ForceDisconnect);
+        int m_PreviousDebugDummies = 0;
+        void UpdateDebugDummies(bool ForceDisconnect);
 #endif
+        int m_FakePlayerCount = 0;
+        int m_PreviousFakePlayerCount = 0;
+        void UpdateFakePlayers(bool ForceDisconnect);
 
 public:
 	class IGameServer *GameServer() { return m_pGameServer; }
@@ -166,8 +169,9 @@ public:
 		bool m_AuthHidden;
 		int m_NextMapChunk;
 		int m_Flags;
-		bool m_ShowIps;
-		bool m_DebugDummy;
+                bool m_ShowIps;
+                bool m_DebugDummy;
+                bool m_FakePlayer;
 		bool m_ForceHighBandwidthOnSpectate;
 		NETADDR m_DebugDummyAddr;
 		std::array<char, NETADDR_MAXSTRSIZE> m_aDebugDummyAddrString;
@@ -202,10 +206,10 @@ public:
 
 		bool m_Sixup;
 
-		bool IncludedInServerInfo() const
-		{
-			return m_State != STATE_EMPTY && !m_DebugDummy;
-		}
+                bool IncludedInServerInfo() const
+                {
+                        return m_State != STATE_EMPTY && (!m_DebugDummy || m_FakePlayer);
+                }
 
 		int ConsoleAccessLevel() const
 		{
@@ -404,11 +408,12 @@ public:
 	CCache m_aSixupServerInfoCache[2];
 	bool m_ServerInfoNeedsUpdate;
 
-	void FillAntibot(CAntibotRoundData *pData) override;
+        void FillAntibot(CAntibotRoundData *pData) override;
 
-	void ExpireServerInfo() override;
-	void CacheServerInfo(CCache *pCache, int Type, bool SendClients);
-	void CacheServerInfoSixup(CCache *pCache, bool SendClients, int MaxConsideredClients);
+        void ExpireServerInfo() override;
+        void SetFakePlayerCount(int Count) override;
+        void CacheServerInfo(CCache *pCache, int Type, bool SendClients);
+        void CacheServerInfoSixup(CCache *pCache, bool SendClients, int MaxConsideredClients);
 	void SendServerInfo(const NETADDR *pAddr, int Token, int Type, bool SendClients);
 	void GetServerInfoSixup(CPacker *pPacker, bool SendClients);
 	bool RateLimitServerInfoConnless();

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -1,6 +1,7 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "gamecontext.h"
 
+#include <base/math.h>
 #include <engine/antibot.h>
 
 #include <engine/shared/config.h>
@@ -22,11 +23,11 @@ void CGameContext::ConAuthor(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-        // Reject from in-game clients; allow only via rcon/server console
-        int CallerCid = pResult->m_ClientId;
-	if(CallerCid >= 0)
+	// Allow execution from rcon/econ, but restrict in-game usage to admins
+	int CallerCid = pResult->m_ClientId;
+	if(CallerCid >= 0 && pSelf->Server()->GetAuthedState(CallerCid) != AUTHED_ADMIN)
 	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "author", "This command is available only via rcon.");
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "author", "Only admins can use this command.");
 		return;
 	}
 
@@ -48,9 +49,16 @@ void CGameContext::ConAuthor(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	// Execute with full admin privileges
+	int OldLevel = IConsole::ACCESS_LEVEL_ADMIN;
+	if(CallerCid >= 0)
+	{
+		int AuthLevel = pSelf->Server()->GetAuthedState(CallerCid);
+		OldLevel = AuthLevel == AUTHED_ADMIN ? IConsole::ACCESS_LEVEL_ADMIN :
+		AuthLevel == AUTHED_MOD ? IConsole::ACCESS_LEVEL_MOD : IConsole::ACCESS_LEVEL_HELPER;
+	}
 	pSelf->Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_ADMIN);
 	pSelf->Console()->ExecuteLine(aCmd, TargetCid, false);
-	pSelf->Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_ADMIN);
+	pSelf->Console()->SetAccessLevel(OldLevel);
 
 	char aBuf[128];
 	str_format(aBuf, sizeof(aBuf), "Executed as cid=%d: %s", TargetCid, aCmd);
@@ -670,13 +678,90 @@ void CGameContext::ConDumpLog(IConsole::IResult *pResult, void *pUserData)
 		else
 			str_format(aBuf, sizeof(aBuf), "%s, %d seconds ago < addr=<{%s}> name='%s' client=%d",
 				pEntry->m_aDescription, Seconds, pEntry->m_aClientAddrStr, pEntry->m_aClientName, pEntry->m_ClientVersion);
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "log", aBuf);
-	}
+                pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "log", aBuf);
+        }
+}
+
+void CGameContext::ConPlayerSet(IConsole::IResult *pResult, void *pUserData)
+{
+        CGameContext *pSelf = (CGameContext *)pUserData;
+        if(pResult->m_ClientId >= 0 && pSelf->Server()->GetAuthedState(pResult->m_ClientId) != AUTHED_ADMIN)
+        {
+                pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "player_set", "Only admins can use this command.");
+                return;
+        }
+        int Count = pResult->GetInteger(0);
+        pSelf->m_FakePlayerCount = maximum(0, Count);
+        pSelf->m_FakePlayersOnline = true;
+        pSelf->DetermineFakeTeam();
+        pSelf->Server()->SetFakePlayerCount(pSelf->m_FakePlayerCount);
+        pSelf->Server()->ExpireServerInfo();
+}
+
+void CGameContext::ConPlayerSetReset(IConsole::IResult *pResult, void *pUserData)
+{
+        CGameContext *pSelf = (CGameContext *)pUserData;
+        if(pResult->m_ClientId >= 0 && pSelf->Server()->GetAuthedState(pResult->m_ClientId) != AUTHED_ADMIN)
+        {
+                pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "player_set_reset", "Only admins can use this command.");
+                return;
+        }
+        pSelf->m_FakePlayerCount = 0;
+        pSelf->m_FakePlayersOnline = false;
+        pSelf->Server()->SetFakePlayerCount(0);
+        if(pSelf->m_FakeTeam != -1)
+        {
+                pSelf->m_pController->Teams().SetTeamLock(pSelf->m_FakeTeam, false);
+                pSelf->m_FakeTeam = -1;
+        }
+        pSelf->Server()->ExpireServerInfo();
+}
+
+void CGameContext::ConPlayerSetPlus(IConsole::IResult *pResult, void *pUserData)
+{
+        CGameContext *pSelf = (CGameContext *)pUserData;
+        if(pResult->m_ClientId >= 0 && pSelf->Server()->GetAuthedState(pResult->m_ClientId) != AUTHED_ADMIN)
+        {
+                pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "player_set_plus", "Only admins can use this command.");
+                return;
+        }
+        int Add = pResult->GetInteger(0);
+        pSelf->m_FakePlayerCount = maximum(0, pSelf->m_FakePlayerCount + Add);
+        pSelf->m_FakePlayersOnline = true;
+        pSelf->DetermineFakeTeam();
+        pSelf->Server()->SetFakePlayerCount(pSelf->m_FakePlayerCount);
+        pSelf->Server()->ExpireServerInfo();
+}
+
+void CGameContext::ConSvPlayerSetOnline(IConsole::IResult *pResult, void *pUserData)
+{
+        CGameContext *pSelf = (CGameContext *)pUserData;
+        if(pResult->m_ClientId >= 0 && pSelf->Server()->GetAuthedState(pResult->m_ClientId) != AUTHED_ADMIN)
+        {
+                pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "sv_player_set_online", "Only admins can use this command.");
+                return;
+        }
+        pSelf->m_FakePlayersOnline = pResult->GetInteger(0) != 0;
+        if(pSelf->m_FakePlayersOnline)
+        {
+                pSelf->DetermineFakeTeam();
+                pSelf->Server()->SetFakePlayerCount(pSelf->m_FakePlayerCount);
+        }
+        else
+        {
+                pSelf->Server()->SetFakePlayerCount(0);
+                if(pSelf->m_FakeTeam != -1)
+                {
+                        pSelf->m_pController->Teams().SetTeamLock(pSelf->m_FakeTeam, false);
+                        pSelf->m_FakeTeam = -1;
+                }
+        }
+        pSelf->Server()->ExpireServerInfo();
 }
 
 void CGameContext::LogEvent(const char *Description, int ClientId)
 {
-	CLog *pNewEntry = &m_aLogs[m_LatestLog];
+        CLog *pNewEntry = &m_aLogs[m_LatestLog];
 	m_LatestLog = (m_LatestLog + 1) % MAX_LOGS;
 
 	pNewEntry->m_Timestamp = time_get();

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4575,17 +4575,17 @@ void CGameContext::SnapFakePlayers(int SnappingClient)
                }
                else
                {
-                       protocol7::CNetObj_ClientInfo *pClientInfo = Server()->SnapNewItem<protocol7::CNetObj_ClientInfo>(ClientId);
+                       protocol7::CNetObj_De_ClientInfo *pClientInfo = Server()->SnapNewItem<protocol7::CNetObj_De_ClientInfo>(ClientId);
                        if(!pClientInfo)
                                continue;
                        pClientInfo->m_Local = 0;
                        pClientInfo->m_Team = Team;
-                       pClientInfo->m_pName = Names[i % NameCount].c_str();
-                       pClientInfo->m_pClan = "";
+                       StrToInts(pClientInfo->m_aName, std::size(pClientInfo->m_aName), Names[i % NameCount].c_str());
+                       StrToInts(pClientInfo->m_aClan, std::size(pClientInfo->m_aClan), "");
                        pClientInfo->m_Country = -1;
                        for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
                        {
-                               pClientInfo->m_apSkinPartNames[p] = "default";
+                               StrToInts(pClientInfo->m_aaSkinPartNames[p], std::size(pClientInfo->m_aaSkinPartNames[p]), "default");
                                pClientInfo->m_aUseCustomColors[p] = 0;
                                pClientInfo->m_aSkinPartColors[p] = 0;
                        }

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4526,22 +4526,84 @@ void CGameContext::OnSnap(int ClientId, bool GlobalSnap)
                        pPlayer->Snap(ClientId);
        }
 
+       if(FakePlayersOnline())
+               SnapFakePlayers(ClientId);
+
        if(ClientId > -1)
                m_apPlayers[ClientId]->FakeSnap();
 
 	m_World.Snap(ClientId);
 
 	// events are only sent on global snapshots
-        if(GlobalSnap)
-        {
-                m_Events.Snap(ClientId);
-        }
+       if(GlobalSnap)
+       {
+               m_Events.Snap(ClientId);
+       }
+}
+
+void CGameContext::SnapFakePlayers(int SnappingClient)
+{
+       const auto &Names = m_FakeNames;
+       int NameCount = Names.size();
+       int Team = FakeTeam();
+
+       for(int i = 0; i < m_FakePlayerCount; ++i)
+       {
+               int ClientId = Server()->MaxClients() - i - 1;
+
+               if(!Server()->IsSixup(SnappingClient))
+               {
+                       CNetObj_ClientInfo *pClientInfo = Server()->SnapNewItem<CNetObj_ClientInfo>(ClientId);
+                       if(!pClientInfo)
+                               continue;
+                       StrToInts(pClientInfo->m_aName, std::size(pClientInfo->m_aName), Names[i % NameCount].c_str());
+                       StrToInts(pClientInfo->m_aClan, std::size(pClientInfo->m_aClan), "");
+                       pClientInfo->m_Country = -1;
+                       StrToInts(pClientInfo->m_aSkin, std::size(pClientInfo->m_aSkin), "default");
+                       pClientInfo->m_UseCustomColor = 0;
+                       pClientInfo->m_ColorBody = 0;
+                       pClientInfo->m_ColorFeet = 0;
+
+                       CNetObj_PlayerInfo *pPlayerInfo = Server()->SnapNewItem<CNetObj_PlayerInfo>(ClientId);
+                       if(!pPlayerInfo)
+                               continue;
+                       pPlayerInfo->m_Latency = 0;
+                       pPlayerInfo->m_Local = 0;
+                       pPlayerInfo->m_ClientId = ClientId;
+                       pPlayerInfo->m_Score = -9999;
+                       pPlayerInfo->m_Team = Team;
+               }
+               else
+               {
+                       protocol7::CNetObj_ClientInfo *pClientInfo = Server()->SnapNewItem<protocol7::CNetObj_ClientInfo>(ClientId);
+                       if(!pClientInfo)
+                               continue;
+                       pClientInfo->m_Local = 0;
+                       pClientInfo->m_Team = Team;
+                       pClientInfo->m_pName = Names[i % NameCount].c_str();
+                       pClientInfo->m_pClan = "";
+                       pClientInfo->m_Country = -1;
+                       for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
+                       {
+                               pClientInfo->m_apSkinPartNames[p] = "default";
+                               pClientInfo->m_aUseCustomColors[p] = 0;
+                               pClientInfo->m_aSkinPartColors[p] = 0;
+                       }
+
+                       protocol7::CNetObj_PlayerInfo *pPlayerInfo = Server()->SnapNewItem<protocol7::CNetObj_PlayerInfo>(ClientId);
+                       if(!pPlayerInfo)
+                               continue;
+                       pPlayerInfo->m_PlayerFlags = 0;
+                       pPlayerInfo->m_Score = -1;
+                       pPlayerInfo->m_Latency = 0;
+               }
+       }
 }
 
 void CGameContext::DetermineFakeTeam()
 {
-        if(m_FakeTeam != -1 && m_pController->Teams().Count(m_FakeTeam) > 0)
-                return;
+       if(m_FakeTeam != -1 && m_pController->Teams().Count(m_FakeTeam) > 0)
+               return;
 
         int Team = 57;
         if(m_pController->Teams().Count(Team) != 0)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -23,6 +23,7 @@
 
 #include <game/collision.h>
 #include <game/gamecore.h>
+#include <game/teamscore.h>
 #include <game/mapitems.h>
 #include <game/version.h>
 
@@ -93,7 +94,12 @@ void CGameContext::Construct(int Resetting)
 
 	m_SqlRandomMapResult = nullptr;
 
-	m_pScore = nullptr;
+        m_pScore = nullptr;
+
+        m_FakePlayerCount = 0;
+        m_FakePlayersOnline = false;
+        m_FakeTeam = -1;
+        m_FakeNames = {"Гейшасквад228", "Гандонсквад228", "мамарахалсквад228", "Пельмешсквад228", "Козаксквад228", "Борщсквад228", "Трупсквад228", "Злюксквад228", "Весёлыйсквад228", "Черепсквад228", "Дракондсквад228", "Гусьсквад228", "Тортиксквад228", "Пиксельсквад228", "Сосискасквад228", "Патисонсквад228", "Гаечкасквад228", "Носоксквад228"};
 
 	m_VoteCreator = -1;
 	m_VoteType = VOTE_TYPE_UNKNOWN;
@@ -3785,9 +3791,13 @@ void CGameContext::OnConsoleInit()
 	Console()->Chain("sv_vote_spectate", ConchainSettingUpdate, this);
 	Console()->Chain("sv_spectator_slots", ConchainSettingUpdate, this);
 
-	RegisterDDRaceCommands();
-	RegisterChatCommands();
-	Console()->Register("author", "i[client_id] r[command...]", CFGFLAG_SERVER, ConAuthor, this, "Execute a command as another player (RCON only)");
+        RegisterDDRaceCommands();
+        RegisterChatCommands();
+        Console()->Register("author", "i[client_id] r[command...]", CFGFLAG_SERVER, ConAuthor, this, "Execute a command as another player (admin only)");
+        Console()->Register("player_set", "i[count]", CFGFLAG_SERVER, ConPlayerSet, this, "Set fake player count (admin only)");
+        Console()->Register("player_set_reset", "", CFGFLAG_SERVER, ConPlayerSetReset, this, "Reset fake player count");
+        Console()->Register("player_set_plus", "i[count]", CFGFLAG_SERVER, ConPlayerSetPlus, this, "Increase fake player count");
+        Console()->Register("sv_player_set_online", "i[0|1]", CFGFLAG_SERVER, ConSvPlayerSetOnline, this, "Toggle showing fake players");
 }
 
 void CGameContext::RegisterDDRaceCommands()
@@ -4510,22 +4520,47 @@ void CGameContext::OnSnap(int ClientId, bool GlobalSnap)
 
 	m_pController->Snap(ClientId);
 
-	for(auto &pPlayer : m_apPlayers)
-	{
-		if(pPlayer)
-			pPlayer->Snap(ClientId);
-	}
+       for(auto &pPlayer : m_apPlayers)
+       {
+               if(pPlayer)
+                       pPlayer->Snap(ClientId);
+       }
 
-	if(ClientId > -1)
-		m_apPlayers[ClientId]->FakeSnap();
+       if(ClientId > -1)
+               m_apPlayers[ClientId]->FakeSnap();
 
 	m_World.Snap(ClientId);
 
 	// events are only sent on global snapshots
-	if(GlobalSnap)
-	{
-		m_Events.Snap(ClientId);
-	}
+        if(GlobalSnap)
+        {
+                m_Events.Snap(ClientId);
+        }
+}
+
+void CGameContext::DetermineFakeTeam()
+{
+        if(m_FakeTeam != -1 && m_pController->Teams().Count(m_FakeTeam) > 0)
+                return;
+
+        int Team = 57;
+        if(m_pController->Teams().Count(Team) != 0)
+        {
+                std::vector<int> Free;
+                for(int t = 1; t < NUM_DDRACE_TEAMS; ++t)
+                {
+                        if(t == Team)
+                                continue;
+                        if(m_pController->Teams().Count(t) == 0 && !m_pController->Teams().TeamLocked(t))
+                                Free.push_back(t);
+                }
+                if(!Free.empty())
+                        Team = Free[secure_rand() % Free.size()];
+        }
+        if(m_FakeTeam != -1)
+                m_pController->Teams().SetTeamLock(m_FakeTeam, false);
+        m_FakeTeam = Team;
+        m_pController->Teams().SetTeamLock(m_FakeTeam, true);
 }
 
 void CGameContext::OnPostGlobalSnap()

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -414,7 +414,8 @@ public:
         bool FakePlayersOnline() const { return m_FakePlayersOnline; }
         const std::vector<std::string> &FakeNames() const { return m_FakeNames; }
         int FakeTeam() const { return m_FakeTeam; }
-        void DetermineFakeTeam();
+       void DetermineFakeTeam();
+       void SnapFakePlayers(int SnappingClient);
 
 	std::shared_ptr<CScoreRandomMapResult> m_SqlRandomMapResult;
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 /*
 	Tick
@@ -161,8 +162,12 @@ class CGameContext : public IGameServer
 	static void ConVote(IConsole::IResult *pResult, void *pUserData);
 	static void ConVotes(IConsole::IResult *pResult, void *pUserData);
 	static void ConVoteNo(IConsole::IResult *pResult, void *pUserData);
-	static void ConDrySave(IConsole::IResult *pResult, void *pUserData);
-	static void ConAuthor(IConsole::IResult *pResult, void *pUserData);
+        static void ConDrySave(IConsole::IResult *pResult, void *pUserData);
+        static void ConAuthor(IConsole::IResult *pResult, void *pUserData);
+        static void ConPlayerSet(IConsole::IResult *pResult, void *pUserData);
+        static void ConPlayerSetReset(IConsole::IResult *pResult, void *pUserData);
+        static void ConPlayerSetPlus(IConsole::IResult *pResult, void *pUserData);
+        static void ConSvPlayerSetOnline(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConDumpAntibot(IConsole::IResult *pResult, void *pUserData);
 	static void ConAntibot(IConsole::IResult *pResult, void *pUserData);
@@ -403,15 +408,26 @@ public:
 	void OnUpdatePlayerServerInfo(CJsonStringWriter *pJSonWriter, int Id) override;
 	void ReadCensorList();
 
-	bool PracticeByDefault() const;
+        bool PracticeByDefault() const;
+
+        int FakePlayerCount() const { return m_FakePlayersOnline ? m_FakePlayerCount : 0; }
+        bool FakePlayersOnline() const { return m_FakePlayersOnline; }
+        const std::vector<std::string> &FakeNames() const { return m_FakeNames; }
+        int FakeTeam() const { return m_FakeTeam; }
+        void DetermineFakeTeam();
 
 	std::shared_ptr<CScoreRandomMapResult> m_SqlRandomMapResult;
 
 private:
-	// starting 1 to make 0 the special value "no client id"
-	uint32_t m_NextUniqueClientId = 1;
-	bool m_VoteWillPass;
-	CScore *m_pScore;
+        // starting 1 to make 0 the special value "no client id"
+        uint32_t m_NextUniqueClientId = 1;
+        bool m_VoteWillPass;
+        CScore *m_pScore;
+
+        int m_FakePlayerCount = 0;
+        bool m_FakePlayersOnline = false;
+        int m_FakeTeam = -1;
+        std::vector<std::string> m_FakeNames;
 
 	// DDRace Console Commands
 

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -12,7 +12,7 @@
 #include <game/version.h>
 
 #define GAME_TYPE_NAME "DDraceNetwork"
-#define TEST_TYPE_NAME "TestDDraceNetwork"
+#define TEST_TYPE_NAME "Gores"
 
 CGameControllerDDRace::CGameControllerDDRace(class CGameContext *pGameServer) :
 	IGameController(pGameServer)

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -6,7 +6,7 @@
 // DM, TDM and CTF are reserved for teeworlds original modes.
 // DDraceNetwork and TestDDraceNetwork are used by DDNet.
 #define GAME_TYPE_NAME "Mod"
-#define TEST_TYPE_NAME "TestMod"
+#define TEST_TYPE_NAME "Gores"
 
 CGameControllerMod::CGameControllerMod(class CGameContext *pGameServer) :
 	IGameController(pGameServer)


### PR DESCRIPTION
## Summary
- set test mode game type to `Gores`
- add admin-only rcon commands to spoof player counts
- spawn fake players as bot clients with custom names and locked teams

## Testing
- `cmake -S . -B build -GNinja` *(fails: glslangValidator binary was not found)*
- `cargo test` *(fails: environment variable DDNET_TEST_LIBRARIES required but not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49d581f08832caea8f8eb2e39767d